### PR TITLE
fix: use correct container registry URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
   # Worker Service - Core claude-mem API
   # ---------------------------------------------------------------------------
   worker:
-    image: ${CLAUDE_MEM_IMAGE:-ghcr.io/sebastienvg/mem-claude:latest}
+    image: ${CLAUDE_MEM_IMAGE:-registry.evthings.space/mem-claude/claude-mem:latest}
     container_name: claude-mem-worker
     ports:
       - "${CLAUDE_MEM_WORKER_PORT:-37777}:37777"


### PR DESCRIPTION
## Summary
Fix docker-compose.yml to use `registry.evthings.space` instead of `ghcr.io`.

The CI workflow (docker-publish.yml) publishes to `registry.evthings.space/mem-claude/claude-mem`, not ghcr.io.

## Before
```yaml
image: ghcr.io/sebastienvg/mem-claude:latest  # Doesn't exist
```

## After
```yaml
image: registry.evthings.space/mem-claude/claude-mem:latest  # Correct
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)