### PR TITLE
ci: auto-publish Docker image on push to main

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,16 @@
 name: Build and Publish Docker Image
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile'
+      - 'docker-entrypoint.sh'
+      - 'src/**'
+      - 'plugin/**'
+      - 'package.json'
+      - '.github/workflows/docker-publish.yml'
   release:
     types: [published]
   workflow_dispatch:
@@ -43,11 +53,13 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=sha,prefix=,format=short
 
       - name: Build and push
         id: build-and-push


### PR DESCRIPTION
## Summary

Automatically publish Docker images when code changes are merged to main.

### Triggers
- **Push to main** (when relevant files change)
- **Release published**
- **Manual workflow dispatch**

### Path filters (only rebuilds when needed)
- `Dockerfile`
- `docker-entrypoint.sh`
- `src/**`
- `plugin/**`
- `package.json`
- `.github/workflows/docker-publish.yml`

### Tags generated
| Tag | Description |
|-----|-------------|
| `latest` | Always points to main/release |
| `main` | Branch name tag |
| `sha-abc1234` | Commit SHA for traceability |
| `v1.2.3` | Semver tags on release |

## Result
After merging, every PR to main automatically publishes an updated Docker image.

```bash
# Users always get the latest
docker compose pull
docker compose up -d
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)