### PR TITLE
fix: remove auth from docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,13 +40,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
## Summary

Remove the login step from docker-publish workflow since registry.evthings.space doesn't require authentication.

## Changes
- Removed `docker/login-action@v3` step
- Removed `REGISTRY_USERNAME` and `REGISTRY_PASSWORD` secret references

🤖 Generated with [Claude Code](https://claude.com/claude-code)