### PR TITLE
fix: docker-entrypoint.sh skip API key warning for Ollama provider

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,8 +8,11 @@ mkdir -p "$CLAUDE_MEM_DATA_DIR/vector-db"
 mkdir -p "$CLAUDE_MEM_DATA_DIR/modes"
 
 # Validate required environment (warn, don't fail - allows read-only mode)
-if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$CLAUDE_MEM_GEMINI_API_KEY" ] && [ -z "$CLAUDE_MEM_OPENROUTER_API_KEY" ]; then
-    echo "WARNING: No AI provider API key set. Memory compression will be disabled."
+# Ollama doesn't require an API key, so skip the warning if Ollama is selected
+if [ "$CLAUDE_MEM_PROVIDER" != "ollama" ]; then
+    if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$CLAUDE_MEM_GEMINI_API_KEY" ] && [ -z "$CLAUDE_MEM_OPENROUTER_API_KEY" ]; then
+        echo "WARNING: No AI provider API key set. Memory compression will be disabled."
+    fi
 fi
 
 # Handle signals for graceful shutdown


### PR DESCRIPTION
Ollama runs locally and doesn't require an API key, so the warning about missing API keys was incorrect when CLAUDE_MEM_PROVIDER=ollama.

## Issues Found During Docker Compose Testing

### 1. API Key Warning (FIXED in this commit)
docker-entrypoint.sh warned "No AI provider API key set" even when using Ollama which doesn't need one.

### 2. Settings Path Mismatch (needs code fix)
Worker creates settings at /home/bun/.claude-mem/ instead of respecting CLAUDE_MEM_DATA_DIR=/data environment variable.
- Workaround: Create symlink /home/bun/.claude-mem -> /data
- Root cause: SettingsDefaultsManager initialization order

### 3. Container Networking Settings (needs defaults fix) Default settings use localhost URLs which don't work in containers:
- CLAUDE_MEM_WORKER_HOST: needs 0.0.0.0 (not 127.0.0.1)
- CLAUDE_MEM_CHROMA_URL: needs http://chroma:8000 (not localhost)
- CLAUDE_MEM_OLLAMA_URL: needs http://ollama:11434 (not localhost)

### 4. CRITICAL: Ollama Session Routing Missing (needs rebuild) The built worker-service.cjs in the registry image is missing the `case 'ollama':` in the startGeneratorWithProvider switch statement.

Source code (SessionRoutes.ts:137-141):
```typescript
case 'ollama':
  agent = this.ollamaAgent;
  agentName = 'Ollama';
  break;
```

Built code (worker-service.cjs) only has:
```javascript
let i=a==="openrouter"?this.openRouterAgent:a==="gemini"?this.geminiAgent:this.sdkAgent
```

This causes Ollama provider to fall back to SDKAgent which fails with "Claude executable not found" error.

### 5. esbuild Minification Issue (needs investigation) isOllamaSelected() env var check is stripped during build:

Source:
```typescript
if (process.env.CLAUDE_MEM_PROVIDER) {
  return process.env.CLAUDE_MEM_PROVIDER === 'ollama';
}
```

Built (env check removed):
```javascript
function Tx(){return Me.loadFromFile(Cr).CLAUDE_MEM_PROVIDER==="ollama
```

## Action Required
Rebuild Docker image from current source code to include:
- This entrypoint fix
- Ollama session routing in switch statement
- Fix env var checks in isOllamaSelected()