### PR TITLE
docs: add spec-first protocol to agent onboarding (bd-2km)

### DIFF
--- a/agentspaces/davinci/CLAUDE.md
+++ b/agentspaces/davinci/CLAUDE.md
@@ -15,6 +15,7 @@ You are **Da Vin Cee**, Senior Engineer and Planner for the claude-mem project.
 
 1. **Research** — Explore the codebase, understand constraints, identify patterns
 2. **Design** — Write highly detailed plans with file paths, code snippets, acceptance criteria, dependency order
+   When creating beads, always write numbered, testable acceptance criteria so agents have a clear starting point for their spec and tests.
 3. **Hand off to Max** — Write the plan to a file, then dispatch it to Max (Project Manager) who assigns agents
 4. **Review** — Review PRs and agent output for quality
 

--- a/agentspaces/max/CLAUDE.md
+++ b/agentspaces/max/CLAUDE.md
@@ -60,6 +60,10 @@ cat > /Users/seb/AI/mem-claude/agentspaces/<name>/TASK.md << 'EOF'
 ## Context
 <relevant files, architecture notes, constraints>
 
+## Protocol Reminder
+Write SPEC.md and tests BEFORE any implementation code.
+Your task is not complete until all spec criteria are met and all tests pass.
+
 ## Scope
 <what's in scope, what's NOT in scope>
 EOF
@@ -155,6 +159,15 @@ On your first message, verify your environment is working:
    - If it fails, check `.beads/redirect` exists in your repo dir.
 6. **Registration**: Run `curl -s http://localhost:37777/api/agents/me -H "Authorization: Bearer $(cat .claude/.agent-key)" | jq .`
    - Should return your agent profile.
+
+## Completion Validation
+
+Before closing a bead, verify:
+- [ ] SPEC.md exists in agent workspace
+- [ ] Tests exist and pass
+- [ ] All spec acceptance criteria are met
+- [ ] PR references the bead ID
+- [ ] GH issue commented (if applicable)
 
 ## Rules
 

--- a/agentspaces/start-agent.sh
+++ b/agentspaces/start-agent.sh
@@ -375,6 +375,32 @@ ${AGENT_TASK:+
 > ${AGENT_TASK}
 }
 
+## Development Protocol
+
+**Spec first, tests first, code last.**
+
+Before writing ANY implementation code, you MUST:
+
+1. **Write SPEC.md** in your workspace root (\`<workspace>/SPEC.md\`):
+   - What you're building (one paragraph)
+   - Acceptance criteria (numbered list, measurable)
+   - Edge cases and error handling
+   - Files you expect to create or modify
+
+2. **Write tests** that validate every acceptance criterion:
+   - Tests go in the project's existing test directory/pattern
+   - Tests MUST fail before implementation (red phase)
+   - Run tests to confirm they fail: document the output
+
+3. **Implement** until all tests pass (green phase)
+
+4. **Verify** all acceptance criteria from SPEC.md are met
+
+A task is NOT complete until:
+- All spec criteria are fulfilled
+- All tests pass
+- SPEC.md exists in your workspace
+
 ## Git Workflow
 
 **CRITICAL: Never commit to or push to main/master.**


### PR DESCRIPTION
## Summary
- **start-agent.sh**: Added `## Development Protocol` section to CLAUDE.md heredoc template (between Task and Git Workflow), requiring agents to write SPEC.md and tests before implementation
- **max/CLAUDE.md**: Added `## Protocol Reminder` in the TASK.md template and `## Completion Validation` checklist for bead closure
- **davinci/CLAUDE.md**: Added testable acceptance criteria reminder to the Design step in the planning workflow

## Test plan
- [ ] Verify start-agent.sh heredoc generates CLAUDE.md with Development Protocol section
- [ ] Verify max/CLAUDE.md TASK.md template includes Protocol Reminder
- [ ] Verify max/CLAUDE.md has Completion Validation checklist
- [ ] Verify davinci/CLAUDE.md has testable AC reminder in Design step
- [ ] Confirm no existing content was removed (GH Issue Closure Protocol sections preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)