### PR TITLE
Add agent-status.sh, dispatch --timeout, TASK.md lifecycle (bd-3nb + bd-eh1)

### DIFF
--- a/agentspaces/agent-status.sh
+++ b/agentspaces/agent-status.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Check if an agent tmux session is idle or busy
+# Usage: ./agent-status.sh <agent-name>
+# Exit: 0 = idle, 1 = busy, 2 = session not found
+# Output: "idle", "busy", or "not-found"
+
+set -euo pipefail
+
+AGENT="${1:?Usage: $0 <agent-name>}"
+SESSION="agent-${AGENT}"
+
+if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+    echo "not-found"
+    exit 2
+fi
+
+PANE=$(tmux capture-pane -t "$SESSION" -p -S -6)
+
+# Busy patterns — agent is actively working
+if echo "$PANE" | grep -qE '(Cogitat|Sautéed|Crunch|Bak|Scurr|Running\.\.\.|Running…|thinking|✻|⏵⏵.*bypass|· Scurrying|· Thinking|· Working|· Creating|· Effecting)'; then
+    echo "busy"
+    exit 1
+fi
+
+# Idle patterns — agent is waiting for input
+# Claude Code prompt (❯), shell prompt ($, %), or separator line before prompt
+if echo "$PANE" | grep -qE '(^❯|^  ❯|[$%]\s*$)'; then
+    echo "idle"
+    exit 0
+fi
+
+# Fallback: if no clear signal, assume busy (safer)
+echo "busy"
+exit 1

--- a/agentspaces/davinci/CLAUDE.md
+++ b/agentspaces/davinci/CLAUDE.md
@@ -40,6 +40,8 @@ sleep 0.3
 tmux send-keys -t agent-max C-m
 ```
 
+**Note:** TASK.md is ephemeral. Max deletes it after reading. If it still exists from a previous dispatch, it was not consumed — overwrite is safe.
+
 ## Task Tracking (Beads)
 
 Track work using `bd` (beads), a git-backed issue tracker shared across all agents.

--- a/agentspaces/max/CLAUDE.md
+++ b/agentspaces/max/CLAUDE.md
@@ -90,18 +90,22 @@ git worktree add ../worktrees/<sub-task> -b <parent>/<sub-task>
 - Remove worktrees before running tests (Bun discovers test files recursively)
 - After merging sub-agent work, clean up: `git worktree remove`
 
-## Tmux Rules
-
-### NEVER write to a busy session
-Always verify the agent is idle before sending keys. Check for:
-- Shell prompt (`$`, `%`) at the end of the pane → agent finished
-- Claude Code prompt → agent waiting for input
-- Spinner/progress text → agent is **busy**, DO NOT send keys
+### Agent Status Detection
+Use `agentspaces/agent-status.sh <name>` to check if an agent is idle or busy:
+- Exit 0 = idle (safe to send), Exit 1 = busy (do NOT send)
+- Or use `dispatch.sh` which checks automatically and waits with `--wait`
+- NEVER use raw `tmux send-keys` — always use `dispatch.sh`
 
 ### Monitoring agents
 - `tmux capture-pane -t agent-<name> -p -S -50` — see recent output
 - `git log --oneline -10` in the agent's repo — verify commits
 - Agents can hallucinate commit hashes — always verify with actual git commands
+
+## TASK.md Protocol
+- Write TASK.md to agent workspace BEFORE dispatching
+- After agent reads TASK.md, it DELETES it immediately: `rm TASK.md`
+- If TASK.md still exists when you check an agent workspace, the previous dispatch was not consumed
+- Always overwrite — the agent is expected to have deleted it after reading
 
 ## Memory & Knowledge
 

--- a/agentspaces/start-agent.sh
+++ b/agentspaces/start-agent.sh
@@ -378,6 +378,8 @@ You are **${AGENT_NAME}**, a ${AGENT_ROLE} working on the claude-mem project.
 ## Task
 
 Read \`TASK.md\` in your workspace for your current assignment.
+**After reading TASK.md, DELETE it immediately:** \`rm ../TASK.md\`
+This prevents stale instructions from interfering with future dispatches.
 ${AGENT_TASK:+
 > ${AGENT_TASK}
 }


### PR DESCRIPTION
## Summary
- **New `agent-status.sh`**: standalone script for idle/busy/not-found detection with expanded busy patterns (Cogitat, Sautéed, Crunch, Scurr, etc.) and proper exit codes (0=idle, 1=busy, 2=not-found)
- **`dispatch.sh` improvements**: delegates idle detection to `agent-status.sh`, adds `--timeout N` flag (default 60s)
- **TASK.md lifecycle protocol**: agents delete TASK.md after reading to prevent stale instructions — documented in Max's CLAUDE.md, Davinci's CLAUDE.md, and the start-agent.sh template

## Test plan
- [ ] Run `./agentspaces/agent-status.sh <running-agent>` and verify idle/busy output
- [ ] Run `./agentspaces/agent-status.sh nonexistent` and verify "not-found" with exit 2
- [ ] Run `./agentspaces/dispatch.sh <agent> --wait --timeout 5 "test"` and verify timeout behavior
- [ ] Verify Max's CLAUDE.md references agent-status.sh and TASK.md protocol
- [ ] Verify Davinci's CLAUDE.md has ephemeral TASK.md note
- [ ] Launch a new agent and verify CLAUDE.md template includes delete-after-reading instruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)