### PR TITLE
Guard planner session: dispatch.sh blocklist + CLAUDE.md updates (bd-2us)

### DIFF
--- a/agentspaces/davinci/CLAUDE.md
+++ b/agentspaces/davinci/CLAUDE.md
@@ -96,6 +96,11 @@ When creating beads linked to GH issues, always include:
 - Explicit instruction that the resolving agent must comment on the issue with resolution details before closing
 - Format: `gh issue close <N> --comment 'Resolved in PR #M. <summary>'`
 
+## How Others Reach You
+- **Human**: direct prompt in your tmux session
+- **Max / Agents**: bead updates only (`bd update <id> --description 'status...'`)
+- Nobody may send tmux keystrokes to your session. Ever. dispatch.sh enforces this.
+
 ## Rules
 
 - **NEVER push to main/master** — always work on your branch

--- a/agentspaces/dispatch.sh
+++ b/agentspaces/dispatch.sh
@@ -52,6 +52,15 @@ if ! tmux has-session -t "$SESSION" 2>/dev/null; then
     exit 1
 fi
 
+# --- Protected sessions — never send keystrokes to these ---
+PROTECTED_SESSIONS="${DISPATCH_PROTECTED:-agent-davinci}"
+
+if echo " $PROTECTED_SESSIONS " | grep -qw "$SESSION"; then
+    echo "ERROR: Cannot dispatch to protected session '${SESSION}'." >&2
+    echo "  Use beads to communicate with the planner: bd update <id> --description 'status...'" >&2
+    exit 1
+fi
+
 # --- Check if agent is idle ---
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/agentspaces/max/CLAUDE.md
+++ b/agentspaces/max/CLAUDE.md
@@ -177,6 +177,8 @@ Before closing a bead, verify:
 
 - Always understand before you plan, and plan before you execute
 - **NEVER push to main/master** — always branch, always PR
+- **NEVER interact with davinci's session** — no tmux keystrokes, no dispatch, no send-keys
+- Da Vin Cee is contactable ONLY via beads or by a human. To report back: `bd update <id> --description 'Status update...'`
 - Break complex work into parallel tracks wherever possible
 - Write clear, unambiguous TASK.md files — agents work autonomously
 - Commit your plans and tracking docs frequently

--- a/agentspaces/start-agent.sh
+++ b/agentspaces/start-agent.sh
@@ -472,6 +472,7 @@ On your first message, verify your environment is working:
 ## Rules
 
 - **NEVER push to main/master** — always work on your branch
+- NEVER interact with agent-davinci or agent-max sessions — report through beads and workspace files only
 - Commit your work frequently with clear messages
 - Stay within scope of your assigned task
 - If blocked, document the blocker in your workspace and stop


### PR DESCRIPTION
## Summary
- Added protected sessions blocklist to `dispatch.sh` — `agent-davinci` is blocked by default, configurable via `DISPATCH_PROTECTED` env var
- Updated Max's CLAUDE.md with explicit prohibition against interacting with davinci's session
- Added "How Others Reach You" section to davinci's CLAUDE.md documenting bead-only contact
- Updated `start-agent.sh` template so all new agents get the rule against interacting with davinci/max sessions

## Test plan
- [ ] `dispatch.sh davinci "test"` exits with error, refuses to send
- [ ] `DISPATCH_PROTECTED="agent-davinci agent-max" dispatch.sh davinci "test"` also refuses
- [ ] `dispatch.sh bd-xxx-shell "test"` still works (not protected)
- [ ] Max's CLAUDE.md has explicit davinci prohibition
- [ ] Davinci's CLAUDE.md has "How Others Reach You"
- [ ] Agent template has rule against interacting with davinci/max

🤖 Generated with [Claude Code](https://claude.com/claude-code)