### PR TITLE
Update CLAUDE.md template: registration confirm with manual fallback (bd-2xx)

### DIFF
--- a/agentspaces/start-agent.sh
+++ b/agentspaces/start-agent.sh
@@ -466,8 +466,10 @@ On your first message, verify your environment is working:
 4. **Report status**: Briefly confirm all checks pass before starting work.
 5. **Beads**: Run \`bd list\` to confirm beads is connected.
    - If it fails, check \`.beads\` is symlinked to the shared bead repo.
-6. **Registration**: Run \`curl -s ${WORKER_URL}/api/agents/me -H "Authorization: Bearer \$(cat .claude/.agent-key)" | jq .\`
+6. **Registration**: Confirm you are registered (auto-registered on launch):
+   \`curl -s ${WORKER_URL}/api/agents/me -H "Authorization: Bearer \$(cat .claude/.agent-key)" | jq .\`
    - Should return your agent profile.
+   - If this fails, register manually: \`curl -X POST ${WORKER_URL}/api/agents/register -H 'Content-Type: application/json' -d '{"id": "${AGENT_NAME}@\$(hostname -s)", "department": "engineering"}'\`
 
 ## Rules
 


### PR DESCRIPTION
## Summary
- Changed registration step in CLAUDE.md template from "Run" (verify) to "Confirm you are registered (auto-registered on launch)"
- Added manual fallback command for cases where auto-registration fails

## Test plan
- [ ] Verify `start-agent.sh` still generates valid CLAUDE.md with updated registration step
- [ ] Confirm manual fallback curl command is syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)