### PR TITLE
Change pr-watcher default POLL_INTERVAL to 120s (bd-387)

### DIFF
--- a/agentspaces/pr-watcher.sh
+++ b/agentspaces/pr-watcher.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 # --- Defaults ---
-POLL_INTERVAL=60
+POLL_INTERVAL=120
 DRY_RUN=false
 ONCE=false
 MAX_RETRIES=${PR_WATCHER_MAX_RETRIES:-3}


### PR DESCRIPTION
## Summary
- Update default `POLL_INTERVAL` from 60s to 120s in `agentspaces/pr-watcher.sh`

## Test plan
- [ ] Verify pr-watcher uses 120s interval by default when run without `--interval` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)