### PR TITLE
feat: pr-watcher launchd persistence (bd-22d)

### DIFF
--- a/agentspaces/README.md
+++ b/agentspaces/README.md
@@ -1,0 +1,58 @@
+# Agent Infrastructure
+
+Scripts for managing the claude-mem agent fleet.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `start-agent.sh` | Launch a new agent (clone repo, checkout branch, start Claude in tmux) |
+| `dispatch.sh` | Send instructions to a running agent (busy detection, temp files for long messages) |
+| `agent-status.sh` | Check if an agent is idle or busy |
+| `pr-watcher.sh` | Poll for mergeable agent PRs and auto-merge them |
+| `pr-watcher-service.sh` | Install/manage pr-watcher as a launchd service |
+
+## pr-watcher Service
+
+The pr-watcher auto-merges agent PRs that are mergeable and don't have a "do not merge" label. It recognizes branches from:
+- Bead-based agents: `bd-*`
+- Named agents: any branch prefix matching a directory in `agentspaces/`
+
+### Install as launchd service (recommended)
+
+```bash
+./pr-watcher-service.sh install
+```
+
+This will:
+- Create the log directory at `~/.claude-mem/logs/`
+- Kill any existing tmux pr-watcher session
+- Install and load the launchd plist
+- Auto-start on boot, auto-restart on crash
+
+### Manage the service
+
+```bash
+./pr-watcher-service.sh status    # Check if running
+./pr-watcher-service.sh logs      # Tail recent output
+./pr-watcher-service.sh restart   # Restart the service
+./pr-watcher-service.sh uninstall # Stop and remove
+```
+
+### Logs
+
+- stdout: `~/.claude-mem/logs/pr-watcher.log`
+- stderr: `~/.claude-mem/logs/pr-watcher.err`
+
+### Run in tmux (for debugging)
+
+```bash
+export BEADS_NO_DAEMON=1
+./pr-watcher.sh --interval 120
+```
+
+Or with `--dry-run` to see what would be merged without merging:
+
+```bash
+./pr-watcher.sh --once --dry-run
+```

--- a/agentspaces/com.claude-mem.pr-watcher.plist
+++ b/agentspaces/com.claude-mem.pr-watcher.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-mem.pr-watcher</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/seb/AI/mem-claude/agentspaces/pr-watcher.sh</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/seb/AI/mem-claude</string>
+
+    <key>StandardOutPath</key>
+    <string>/Users/seb/.claude-mem/logs/pr-watcher.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/seb/.claude-mem/logs/pr-watcher.err</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/Users/seb/.local/bin:/Users/seb/.bun/bin</string>
+        <key>HOME</key>
+        <string>/Users/seb</string>
+        <key>BEADS_NO_DAEMON</key>
+        <string>1</string>
+    </dict>
+</dict>
+</plist>

--- a/agentspaces/pr-watcher-service.sh
+++ b/agentspaces/pr-watcher-service.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Manage the pr-watcher launchd service.
+#
+# Usage: ./pr-watcher-service.sh <install|uninstall|status|logs|restart>
+
+set -euo pipefail
+
+PLIST_NAME="com.claude-mem.pr-watcher"
+PLIST_SRC="$(cd "$(dirname "$0")" && pwd)/${PLIST_NAME}.plist"
+PLIST_DST="$HOME/Library/LaunchAgents/${PLIST_NAME}.plist"
+LOG_DIR="$HOME/.claude-mem/logs"
+
+cmd="${1:-help}"
+
+case "$cmd" in
+    install)
+        # Create log directory
+        mkdir -p "$LOG_DIR"
+
+        # Kill tmux pr-watcher session if running (clean transition)
+        if tmux has-session -t pr-watcher 2>/dev/null; then
+            echo "Killing existing tmux pr-watcher session..."
+            tmux kill-session -t pr-watcher
+        fi
+
+        # Unload existing service if loaded
+        launchctl bootout "gui/$(id -u)/${PLIST_NAME}" 2>/dev/null || true
+
+        # Copy plist
+        cp "$PLIST_SRC" "$PLIST_DST"
+        echo "Installed plist to $PLIST_DST"
+
+        # Load service
+        launchctl bootstrap "gui/$(id -u)" "$PLIST_DST"
+        echo "Service loaded."
+
+        # Verify
+        sleep 2
+        if launchctl print "gui/$(id -u)/${PLIST_NAME}" >/dev/null 2>&1; then
+            echo "pr-watcher is running."
+        else
+            echo "WARNING: service may not have started. Check: $0 status"
+        fi
+        ;;
+
+    uninstall)
+        launchctl bootout "gui/$(id -u)/${PLIST_NAME}" 2>/dev/null || true
+        rm -f "$PLIST_DST"
+        echo "Service unloaded and plist removed."
+        ;;
+
+    status)
+        if launchctl print "gui/$(id -u)/${PLIST_NAME}" 2>/dev/null | grep -qE 'state = running'; then
+            echo "pr-watcher: running"
+            launchctl print "gui/$(id -u)/${PLIST_NAME}" 2>/dev/null | grep -E '(state|pid|last exit)'
+        else
+            echo "pr-watcher: not running"
+            launchctl print "gui/$(id -u)/${PLIST_NAME}" 2>/dev/null | grep -E '(state|last exit)' || echo "(service not loaded)"
+        fi
+        ;;
+
+    logs)
+        echo "=== stdout ==="
+        tail -30 "$LOG_DIR/pr-watcher.log" 2>/dev/null || echo "(no log file yet)"
+        echo ""
+        echo "=== stderr ==="
+        tail -10 "$LOG_DIR/pr-watcher.err" 2>/dev/null || echo "(no error log yet)"
+        ;;
+
+    restart)
+        launchctl kickstart -k "gui/$(id -u)/${PLIST_NAME}" 2>/dev/null || {
+            echo "Service not loaded. Run: $0 install"
+            exit 1
+        }
+        echo "pr-watcher restarted."
+        ;;
+
+    help|*)
+        echo "Usage: $0 <install|uninstall|status|logs|restart>"
+        echo ""
+        echo "  install    Copy plist, create log dir, load service"
+        echo "  uninstall  Unload service, remove plist"
+        echo "  status     Show service status"
+        echo "  logs       Tail recent log output"
+        echo "  restart    Restart the service"
+        ;;
+esac

--- a/agentspaces/pr-watcher.sh
+++ b/agentspaces/pr-watcher.sh
@@ -23,7 +23,7 @@ while [[ $# -gt 0 ]]; do
         --once)     ONCE=true; shift ;;
         -h|--help)
             echo "Usage: $0 [--interval <seconds>] [--dry-run] [--once]"
-            echo "  --interval N  Poll every N seconds (default 60)"
+            echo "  --interval N  Poll every N seconds (default 120)"
             echo "  --dry-run     Log what would happen without merging"
             echo "  --once        Run one pass and exit"
             exit 0


### PR DESCRIPTION
## Summary
- Add launchd plist so pr-watcher auto-starts on boot and auto-restarts on crash
- Add `pr-watcher-service.sh` management script (install/uninstall/status/logs/restart)
- Fix help text default interval (60 -> 120)
- Add `agentspaces/README.md` documenting all agent infrastructure scripts

Closes #63
Bead: bd-22d

## Files
| Action | File |
|--------|------|
| CREATE | `agentspaces/com.claude-mem.pr-watcher.plist` |
| CREATE | `agentspaces/pr-watcher-service.sh` |
| MODIFY | `agentspaces/pr-watcher.sh` (help text fix) |
| CREATE | `agentspaces/README.md` |

## Test plan
- [ ] `./pr-watcher-service.sh install` — service starts, appears in `launchctl list`
- [ ] `./pr-watcher-service.sh status` — shows running
- [ ] `./pr-watcher-service.sh logs` — shows poll output
- [ ] Reboot machine — service auto-starts
- [ ] Kill pr-watcher process — launchd restarts it within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)