### PR TITLE
fix: enable MCP tools in agent workspaces

### DIFF
--- a/agentspaces/start-agent.sh
+++ b/agentspaces/start-agent.sh
@@ -295,9 +295,26 @@ if [ ! -f "$AGENT_SETTINGS" ]; then
     "type": "command",
     "command": "/Users/seb/AI/mem-claude/agentspaces/statusline.sh",
     "padding": 0
+  },
+  "enabledPlugins": {
+    "claude-mem@thedotmack": true
   }
 }
 SETTINGS
+fi
+
+# --- Ensure enabledPlugins in existing agent settings (GH #65) ---
+if [ -f "$AGENT_SETTINGS" ]; then
+    if ! python3 -c "import json; d=json.load(open('$AGENT_SETTINGS')); assert 'enabledPlugins' in d" 2>/dev/null; then
+        python3 -c "
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d['enabledPlugins'] = {'claude-mem@thedotmack': True}
+json.dump(d, open(p, 'w'), indent=2)
+print('Added enabledPlugins to', p)
+" "$AGENT_SETTINGS"
+    fi
 fi
 
 # --- Mark lifecycle ---

--- a/scripts/sync-marketplace.cjs
+++ b/scripts/sync-marketplace.cjs
@@ -65,6 +65,22 @@ try {
     { stdio: 'inherit' }
   );
 
+  // Clean up stale root .mcp.json that shadows plugin's MCP config (GH #65)
+  const staleMcpPath = path.join(INSTALLED_PATH, '.mcp.json');
+  if (existsSync(staleMcpPath)) {
+    try {
+      const content = JSON.parse(readFileSync(staleMcpPath, 'utf-8'));
+      if (!content.mcpServers || Object.keys(content.mcpServers).length === 0) {
+        require('fs').unlinkSync(staleMcpPath);
+        console.log('Removed stale root .mcp.json (empty mcpServers)');
+      }
+    } catch {
+      // If it can't be parsed, remove it too
+      require('fs').unlinkSync(staleMcpPath);
+      console.log('Removed unparseable root .mcp.json');
+    }
+  }
+
   console.log('Running npm install in marketplace...');
   execSync(
     'cd ~/.claude/plugins/marketplaces/thedotmack/ && npm install',


### PR DESCRIPTION
## Summary

Fixes #65. Agent workspaces couldn't access `search` and `timeline` MCP tools from the claude-mem plugin.

**Root cause**: `start-agent.sh` wrote agent settings (`$CLAUDE_CONFIG_DIR/settings.json`) with only `statusLine` config — no `enabledPlugins`. Claude Code with a custom `CLAUDE_CONFIG_DIR` reads settings from that directory, so without `enabledPlugins`, the claude-mem plugin was never loaded and its MCP servers never started. All 27 existing agent workspaces were affected.

**Secondary issue**: A stale empty `.mcp.json` (`{"mcpServers": {}}`) persisted at the marketplace root (`~/.claude/plugins/marketplaces/thedotmack/.mcp.json`), potentially shadowing the plugin's correct MCP config at `plugin/.mcp.json`.

## Changes

- **`agentspaces/start-agent.sh`**: Add `enabledPlugins` with `claude-mem@thedotmack: true` to the settings template for new agents. Add migration step that patches existing agent settings missing `enabledPlugins` on next launch.
- **`scripts/sync-marketplace.cjs`**: After rsync, remove stale root `.mcp.json` if it has empty `mcpServers`.

## Verification

- Confirmed all 27 existing agent workspaces were missing `enabledPlugins`
- Patched all existing workspaces
- Removed stale marketplace root `.mcp.json`
- Verified `plugin/.mcp.json` (the correct one) is intact

## Test plan

- [ ] Launch a new agent workspace — verify settings include `enabledPlugins`
- [ ] Relaunch an existing agent — verify migration adds `enabledPlugins`
- [ ] Run `npm run build-and-sync` — verify stale root `.mcp.json` is cleaned up
- [ ] Verify `/mcp` shows `mcp-search` server in agent workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)