### PR TITLE
fix: default worker bind to 0.0.0.0 for LAN access (bd-26y)

### DIFF
--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -82,7 +82,7 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_MODEL: 'claude-sonnet-4-5',
     CLAUDE_MEM_CONTEXT_OBSERVATIONS: '50',
     CLAUDE_MEM_WORKER_PORT: '37777',
-    CLAUDE_MEM_WORKER_HOST: '127.0.0.1',
+    CLAUDE_MEM_WORKER_HOST: '0.0.0.0',
     CLAUDE_MEM_WORKER_URL: '',  // Empty = construct from host+port; set explicitly for container/remote mode
     CLAUDE_MEM_SKIP_TOOLS: 'ListMcpResourcesTool,SlashCommand,Skill,TodoWrite,AskUserQuestion',
     // Chroma Configuration

--- a/src/ui/viewer/constants/settings.ts
+++ b/src/ui/viewer/constants/settings.ts
@@ -6,7 +6,7 @@ export const DEFAULT_SETTINGS = {
   CLAUDE_MEM_MODEL: 'claude-sonnet-4-5',
   CLAUDE_MEM_CONTEXT_OBSERVATIONS: '50',
   CLAUDE_MEM_WORKER_PORT: '37777',
-  CLAUDE_MEM_WORKER_HOST: '127.0.0.1',
+  CLAUDE_MEM_WORKER_HOST: '0.0.0.0',
 
   // AI Provider Configuration
   CLAUDE_MEM_PROVIDER: 'claude',


### PR DESCRIPTION
## Summary
- Changed default `CLAUDE_MEM_WORKER_HOST` from `127.0.0.1` to `0.0.0.0`
- Two files: `SettingsDefaultsManager.ts` and viewer `settings.ts`
- Worker becomes reachable from LAN (viewer UI, API)
- Override with `CLAUDE_MEM_WORKER_HOST=127.0.0.1` in settings if localhost-only is needed

Closes #67
Bead: bd-26y

## Test plan
- [ ] After rebuild, `curl http://<lan-ip>:37777/api/health` returns ok
- [ ] Viewer UI accessible from another device on LAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)