### PR TITLE
feat: A-Teams integration toggle (bd-3io)

### DIFF
--- a/agentspaces/max/CLAUDE.md
+++ b/agentspaces/max/CLAUDE.md
@@ -186,6 +186,31 @@ Before closing a bead, verify:
 - Run tests after integration — never ship broken code
 - When in doubt, ask the user — you serve their vision
 
+## A-Teams (Anthropic Agent Teams)
+
+A-Teams is Anthropic's native parallel agent spawning within Claude Code. It allows an agent to spin up sub-agents (via the Task tool) that run concurrently, each with their own context window.
+
+**Terminology:** Our system is called **Agentspace** (workspace isolation, tmux sessions, start-agent.sh). Anthropic's parallel agents feature is called **A-Teams**. Never confuse them — they are complementary but independent.
+
+### How it's controlled
+
+- Toggle in `~/.claude-mem/agentspace.json` under `runtimes.claude-code.agent-teams` (boolean)
+- When `true`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is exported into agent tmux sessions
+- Default is `false` (opt-in)
+
+### When to recommend A-Teams in TASK.md
+
+Suggest A-Teams usage when dispatching agents for:
+- **Debugging with competing hypotheses** — investigate multiple root causes simultaneously
+- **Research tasks** — explore multiple code paths or documentation areas in parallel
+- **Multi-file features with independent components** — changes that don't touch the same files
+
+### When NOT to use A-Teams
+
+- **Sequential tasks with dependencies** — step B needs output from step A
+- **Same-file edits** — parallel edits to the same file cause merge conflicts
+- **Simple single-file changes** — overhead isn't justified
+
 ## GH Issue Closure Protocol
 
 When a bead or task resolves a GitHub issue, you MUST ensure a resolution comment is posted on the issue before it's closed. This applies both to you (Max) and to any agents you dispatch.

--- a/agentspaces/start-agent.sh
+++ b/agentspaces/start-agent.sh
@@ -17,13 +17,21 @@ shift
 AGENTSPACE_CONFIG="${HOME}/.claude-mem/agentspace.json"
 RUNTIME_CMD="claude"
 RUNTIME_FLAGS="--dangerously-skip-permissions"
+_ATEAMS=""
 if [ -f "$AGENTSPACE_CONFIG" ]; then
     if command -v jq >/dev/null 2>&1; then
         _CMD=$(jq -r '.runtimes["claude-code"].command // empty' "$AGENTSPACE_CONFIG" 2>/dev/null)
         _FLAGS=$(jq -r '.runtimes["claude-code"].flags // empty' "$AGENTSPACE_CONFIG" 2>/dev/null)
         [ -n "$_CMD" ] && RUNTIME_CMD="$_CMD"
         [ -n "$_FLAGS" ] && RUNTIME_FLAGS="$_FLAGS"
+        _ATEAMS=$(jq -r '.runtimes["claude-code"]["agent-teams"] // false' "$AGENTSPACE_CONFIG" 2>/dev/null)
     fi
+fi
+
+# --- Build A-Teams env export ---
+ATEAMS_EXPORT=""
+if [ "$_ATEAMS" = "true" ]; then
+    ATEAMS_EXPORT=" CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1"
 fi
 
 # Parse optional flags
@@ -520,6 +528,25 @@ Human (vision) → Da Vin Cee (plan) → Max (orchestrate) → Agents (execute)
 - Report to Max only — never directly to Da Vin Cee.
 - Only Max dispatches sub-agents.
 
+${_ATEAMS:+
+## A-Teams (Parallel Subtasks)
+
+A-Teams is enabled for your session. You can spawn parallel sub-agents for independent subtasks.
+
+### When to use A-Teams
+- Investigating multiple hypotheses in parallel
+- Research across different code areas
+- Independent file changes that won't conflict
+
+### When NOT to use A-Teams
+- Sequential work with dependencies
+- Edits to the same file (merge conflicts)
+- Simple changes that don't benefit from parallelism
+
+### Usage
+Use the Task tool to spawn sub-agents. Each sub-agent gets its own context.
+Keep your main thread for coordination and integration.
+}
 ## Rules
 
 - **NEVER push to main/master** — always work on your branch
@@ -569,7 +596,7 @@ CLAUDE_MEM_EXPORTS=""
 # Set CLAUDE_CONFIG_DIR in the tmux session and start Claude
 # NOTE: cd to REPO_DIR so Claude works in the agent's own clone.
 tmux send-keys -t "$TMUX_SESSION" \
-    "export CLAUDE_CONFIG_DIR='${CLAUDE_DIR}' AGENT_LIFECYCLE='${AGENT_LIFECYCLE}' AGENT_SPAWNER='${AGENT_NAME}' BEADS_NO_DAEMON=1 BEADS_DIR='${BEAD_REPO_DIR}/.beads' BD_ACTOR='${AGENT_NAME}' ${BEAD_ID:+CURRENT_BEAD='${BEAD_ID}'}${CLAUDE_MEM_EXPORTS} && cd '${REPO_DIR}' && echo 'Starting ${AGENT_NAME} on branch ${AGENT_BRANCH}...' && ${RUNTIME_CMD} ${RUNTIME_FLAGS} ${CLAUDE_RESUME_FLAG}" Enter
+    "export CLAUDE_CONFIG_DIR='${CLAUDE_DIR}' AGENT_LIFECYCLE='${AGENT_LIFECYCLE}' AGENT_SPAWNER='${AGENT_NAME}' BEADS_NO_DAEMON=1 BEADS_DIR='${BEAD_REPO_DIR}/.beads' BD_ACTOR='${AGENT_NAME}' ${BEAD_ID:+CURRENT_BEAD='${BEAD_ID}'}${CLAUDE_MEM_EXPORTS}${ATEAMS_EXPORT} && cd '${REPO_DIR}' && echo 'Starting ${AGENT_NAME} on branch ${AGENT_BRANCH}...' && ${RUNTIME_CMD} ${RUNTIME_FLAGS} ${CLAUDE_RESUME_FLAG}" Enter
 
 echo ""
 echo "Agent '${AGENT_NAME}' launched!"


### PR DESCRIPTION
## Summary
- Read `agent-teams` boolean from `~/.claude-mem/agentspace.json` (`runtimes.claude-code.agent-teams`)
- When `true`, export `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` into agent tmux sessions
- Add A-Teams guidance section to Max's CLAUDE.md (when to recommend, terminology)
- Conditionally include A-Teams section in agent CLAUDE.md heredoc via `${_ATEAMS:+...}`

## Test plan
- [ ] Set `"agent-teams": true` in `agentspace.json`, launch agent → verify `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is in the environment
- [ ] Set `"agent-teams": false` or omit key → verify env var is NOT set
- [ ] Remove `agentspace.json` entirely → verify backward-compatible (no env var)
- [ ] Launch agent with `agent-teams: true` → verify CLAUDE.md includes A-Teams section
- [ ] Launch agent without → verify CLAUDE.md does NOT include A-Teams section

🤖 Generated with [Claude Code](https://claude.com/claude-code)